### PR TITLE
Update to support cohttp 6

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -101,9 +101,7 @@
   (lwt
    (>= "5.3"))
   (cohttp-lwt
-   (and
-    (>= "4.0.0")
-    (< "6")))
+   (>= "6.0.0"))
   (alcotest :with-test))
  (synopsis "Opentelemetry tracing for Cohttp HTTP servers"))
 

--- a/opentelemetry-cohttp-lwt.opam
+++ b/opentelemetry-cohttp-lwt.opam
@@ -18,7 +18,7 @@ depends: [
   "opentelemetry-lwt" {= version}
   "odoc" {with-doc}
   "lwt" {>= "5.3"}
-  "cohttp-lwt" {>= "4.0.0" & < "6"}
+  "cohttp-lwt" {>= "6.0.0"}
   "alcotest" {with-test}
 ]
 build: [


### PR DESCRIPTION
Hello, and thank you for the nice libraries :)

This small PR allows us to use ocaml-opentelemetry with Cohttp 6.

This supports https://github.com/imandra-ai/ocaml-opentelemetry/issues/51 under the assumptions that

1. we want the Eio collector to live in this repository, and
2. we want to use the stable (non-alpha) release of `cohttp-eio` for this collector.
3. we want to be able to build and install all the packages in this repo together.

IMO, (2) should be a hard requirement, but (1) and (3) are negotiable, so this is not a actually a blocker for #51. We could, for instance, just mark `opentelemetry-cohttp-lwt` and the forthcoming `opentelemetry-cohttp-eio` as incompatible packages, and have only the latter depend on `"cohttp" {>= "6.0.0"}`. Please LMK if you'd prefer one of these courses.

I think it is reasonable to consider an update, since preparation for Cohttp 6 started in
2022 (https://github.com/mirage/ocaml-cohttp/blob/main/CHANGES.md#v600alpha0-2022-10-24) and 6 has been stable and released since Nov of 2024. See https://github.com/mirage/ocaml-cohttp/blob/main/CHANGES.md#v600-2024-11-21

The changes proposed here takes the shortest path to getting us Cohttp 6 support, which requires drops compatibility with older major versions of Cohttp. If it is important that we maintain compatibility with Cohttp 4 and 5, this can be achieved at the cost of either (a) some code duplication for a compatibility shim or (b) some conditional compilation.

If the simple update is not feasible, please on advise on the preferred course for a backward compatible update.