### PR TITLE
Fix dependencies

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -44,7 +44,9 @@
    (and
     :with-dev-setup
     (>= 0.27)
-    (< 0.28))))
+    (< 0.28)))
+  (mtime
+    (>= "1.4")))
  (depopts trace lwt eio)
  (conflicts
   (trace
@@ -98,7 +100,13 @@
   (odoc :with-doc)
   (logs
    (>= "0.7.0"))
-  (alcotest :with-test))
+  (alcotest :with-test)
+  (containers :with-test)
+  (cohttp-lwt-unix :with-test)
+  (opentelemetry-client-cohttp-lwt
+   (and :with-test (= :version)))
+  (opentelemetry-cohttp-lwt
+   (and :with-test (= :version))))
  (synopsis "Opentelemetry tracing for Cohttp HTTP servers"))
 
 (package
@@ -136,7 +144,8 @@
   cohttp-lwt
   cohttp-lwt-unix
   (alcotest :with-test)
-  (containers :with-test))
+  (containers :with-test)
+  (opentelemetry-lwt (and :with-test (= :version))))
  (synopsis "Collector client for opentelemetry, using cohttp + lwt"))
 
 (package
@@ -154,7 +163,9 @@
   (cohttp-eio
    (>= 6.1.0))
   (eio_main :with-test)
-  tls-eio
+  (tls-eio
+   (>= 2.0.1))
   (alcotest :with-test)
-  (containers :with-test))
+  (containers :with-test)
+  (cohttp-lwt-unix :with-test))
  (synopsis "Collector client for opentelemetry, using cohttp + eio"))

--- a/opentelemetry-client-cohttp-eio.opam
+++ b/opentelemetry-client-cohttp-eio.opam
@@ -21,9 +21,10 @@ depends: [
   "odoc" {with-doc}
   "cohttp-eio" {>= "6.1.0"}
   "eio_main" {with-test}
-  "tls-eio"
+  "tls-eio" {>= "2.0.1"}
   "alcotest" {with-test}
   "containers" {with-test}
+  "cohttp-lwt-unix" {with-test}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/opentelemetry-client-cohttp-lwt.opam
+++ b/opentelemetry-client-cohttp-lwt.opam
@@ -23,6 +23,7 @@ depends: [
   "cohttp-lwt-unix"
   "alcotest" {with-test}
   "containers" {with-test}
+  "opentelemetry-lwt" {with-test & = version}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/opentelemetry-logs.opam
+++ b/opentelemetry-logs.opam
@@ -18,6 +18,10 @@ depends: [
   "odoc" {with-doc}
   "logs" {>= "0.7.0"}
   "alcotest" {with-test}
+  "containers" {with-test}
+  "cohttp-lwt-unix" {with-test}
+  "opentelemetry-client-cohttp-lwt" {with-test & = version}
+  "opentelemetry-cohttp-lwt" {with-test & = version}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/opentelemetry.opam
+++ b/opentelemetry.opam
@@ -24,6 +24,7 @@ depends: [
   "pbrt" {>= "3.0" & < "4.0"}
   "ocaml-lsp-server" {with-dev-setup}
   "ocamlformat" {with-dev-setup & >= "0.27" & < "0.28"}
+  "mtime" {>= "1.4"}
 ]
 depopts: ["trace" "lwt" "eio"]
 conflicts: [

--- a/tests/bin/dune
+++ b/tests/bin/dune
@@ -23,8 +23,6 @@
 (executable
  (name emit1_eio)
  (modules emit1_eio)
- (preprocess
-  (pps lwt_ppx))
  (enabled_if
   (>= %{ocaml_version} 5.0))
  (libraries

--- a/tests/client_e2e/dune
+++ b/tests/client_e2e/dune
@@ -33,7 +33,7 @@
  (package opentelemetry-client-cohttp-lwt)
  (enabled_if
   (>= %{ocaml_version} 5.0))
- (deps %{bin:emit1_cohttp} %{bin:emit1_eio})
+ (deps %{bin:emit1_cohttp})
  (libraries clients_e2e_lib alcotest opentelemetry opentelemetry.client))
 
 (tests


### PR DESCRIPTION
The opam release in https://github.com/ocaml/opam-repository/pull/28469 revealed a couple of incorrectly specified dependencies.

Some deps where not needed. Some packages did not declare all their needed package deps.

This only affected tests. This PR fixes the sources.