### PR TITLE
fix: mutex usage and inline bugs

### DIFF
--- a/src/core/lock.ml
+++ b/src/core/lock.ml
@@ -8,4 +8,10 @@ let set_mutex ~lock ~unlock : unit =
 
 let[@inline] with_lock f =
   !lock_ ();
-  Fun.protect ~finally:!unlock_ f
+  match f () with
+  | x ->
+    !unlock_ ();
+    x
+  | exception e ->
+    !unlock_ ();
+    Printexc.raise_with_backtrace e (Printexc.get_raw_backtrace ())


### PR DESCRIPTION
closes https://github.com/imandra-ai/ocaml-opentelemetry/issues/113

We noticed that occasionally we would have an asynchronous exception get raised while sending metrics (e.g. a timeout, gc alarm etc.), B_queue wouldn't release its mutex on this exception leading to a deadlock. We first tried patching this via using the protect function in client/batch.ml, but it seems like the use of Fun.protect would cause flambda to sometimes move things out of order. So we switched the protect function to be an almost exact copy paste of that in Stdlib 5.1, and that seems to have worked.

This patch also changes the locks in client/batch.ml and in core/lock.ml to not use Fun.protect, since I suspect that the same issue w/flambda may occur there too